### PR TITLE
NativeAOT Compatibility for WhenAny extension

### DIFF
--- a/ReactiveGenerator/WhenAnyValueGenerator.cs
+++ b/ReactiveGenerator/WhenAnyValueGenerator.cs
@@ -322,6 +322,7 @@ using System;
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Threading;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ReactiveGenerator.Internal
 {
@@ -330,7 +331,7 @@ namespace ReactiveGenerator.Internal
     /// </summary>
     /// <typeparam name=""TSource"">The type of the source object.</typeparam>
     /// <typeparam name=""TProperty"">The type of the property being observed.</typeparam>
-    internal sealed class PropertyObserver<TSource, TProperty> : IObservable<TProperty>, IDisposable
+    internal sealed class PropertyObserver<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents)] TSource, TProperty> : IObservable<TProperty>, IDisposable
         where TSource : INotifyPropertyChanged
     {
         private readonly object _gate = new object();


### PR DESCRIPTION
The `WhenAny` extension methods are not native-aot compatible at this time, as they uses reflection for the `PropertyChanged` event.

Running the demo app in native-aot mode causes the following exception:
```txt
System.ArgumentException: Event 'PropertyChanged' not found on type 'ReactiveGeneratorDemo.ViewModels.Person'.
   at ReactiveGenerator.Internal.WeakEventManager`1.AddEventHandler(Object, String, TDelegate) + 0x28e
   at ReactiveGenerator.Internal.PropertyObserver`2.Subscribe(IObserver`1) + 0xf8
--- End of stack trace from previous location ---
   at System.Reactive.Stubs.<>c.<.cctor>b__2_1(Exception) + 0x50
   at ReactiveGenerator.Internal.PropertyObserver`2.Subscribe(IObserver`1) + 0x185
   at ReactiveGeneratorDemo.MainWindow..ctor() + 0x148
   at ReactiveGeneratorDemo.App.OnFrameworkInitializationCompleted() + 0x39
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder, String[], Action`1) + 0x2f
   at ReactiveGeneratorDemo.Program.Main(String[] args) + 0x71
```

The solution was implemented by adding the attribute `DynamicallyAccessedMembers` to ``PropertyObserver`2.TSource``, which tells the compiler to keep the object's events from being trimmed