### PR TITLE
Do not make ObservableAsPropertyHelper readonly

### DIFF
--- a/ReactiveGenerator/ObservableAsPropertyHelperGenerator.cs
+++ b/ReactiveGenerator/ObservableAsPropertyHelperGenerator.cs
@@ -294,7 +294,7 @@ public class ObservableAsPropertyHelperGenerator : IIncrementalGenerator
             sb.AppendLine($"{indent}/// </summary>");
         }
 
-        sb.AppendLine($"{indent}private readonly ObservableAsPropertyHelper<{nullablePropertyType}> {backingFieldName};");
+        sb.AppendLine($"{indent}private ObservableAsPropertyHelper<{nullablePropertyType}> {backingFieldName};");
         sb.AppendLine();
 
         // Add XML documentation for the property


### PR DESCRIPTION
Fixes https://github.com/wieslawsoltes/ReactiveGenerator/issues/23