### PR TITLE
Add check for NotNull constraint on type parameters

### DIFF
--- a/ReactiveGenerator/ReactiveGenerator.cs
+++ b/ReactiveGenerator/ReactiveGenerator.cs
@@ -507,6 +507,8 @@ public class ReactiveGenerator : IIncrementalGenerator
                     paramConstraints.Add("struct");
                 if (typeParam.HasConstructorConstraint)
                     paramConstraints.Add("new()");
+                if (typeParam.HasNotNullConstraint)
+                    paramConstraints.Add("notnull");
 
                 var typeConstraint = string.Join(", ", typeParam.ConstraintTypes.Select(t =>
                     t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));


### PR DESCRIPTION
Introduced a condition to check for the `HasNotNullConstraint` property on `typeParam`. If present, the string "notnull" is added to the `paramConstraints` list, ensuring the `notnull` constraint is included in the type parameter constraints.